### PR TITLE
Fix upload-artifact version

### DIFF
--- a/.github/workflows/sorting-slides.yml
+++ b/.github/workflows/sorting-slides.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Build PPTX
         run: pandoc sorting.md -o sorting.pptx
       - name: Upload artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: sorting-slides
           path: |


### PR DESCRIPTION
## Summary
- use `actions/upload-artifact@v4` in sorting-slides workflow

## Testing
- `script/test` *(fails: No tests)*