### PR TITLE
Ensure Pandoc uses slide-level flag

### DIFF
--- a/.github/workflows/sorting-slides.yml
+++ b/.github/workflows/sorting-slides.yml
@@ -17,9 +17,9 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y pandoc texlive-latex-recommended texlive-latex-extra texlive-fonts-recommended
       - name: Build PDF (Beamer)
-        run: pandoc sorting.md -t beamer -o sorting.pdf
+        run: pandoc sorting.md --slide-level=4 -t beamer -o sorting.pdf
       - name: Build PPTX
-        run: pandoc sorting.md -o sorting.pptx
+        run: pandoc sorting.md --slide-level=4 -o sorting.pptx
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- add `--slide-level=4` to pandoc commands in sorting-slides workflow

## Testing
- `git log -1 --stat`